### PR TITLE
test if media is m3u8 if URL doesn't contain m3u8

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
+  http: ^0.13.3
   meta: ^1.3.0
   video_player_platform_interface: ^4.1.0
   js: ^0.6.3


### PR DESCRIPTION
This allows playing HLS video from URLs that do not contain `m3u8`, e. g. blobs.
If the URL does not contain `m3u8` the first 1024 bytes are downloaded using a [HTTP range request](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests) to verify if the file is a HLS playlist by testing if it contains `#EXTM3U`.

Note:
- For this to work the HTTP Server needs to support HTTP range request. However this is widely supported by Apache, Nginx, S3 and many othes
- Existing range headers set by users of the library are generally accounted for. However only the first range is used for file type verification
- To allow HTTP requests the package [`http`](https://pub.dev/packages/http) was added as a dependency