### PR TITLE
Fix subsequent xhr requests withCredentials

### DIFF
--- a/lib/video_player_web_hls.dart
+++ b/lib/video_player_web_hls.dart
@@ -237,10 +237,11 @@ class _VideoPlayer {
 
                 if (headers.containsKey("useCookies")) {
                   xhr.withCredentials = true;
-                  headers.remove("useCookies");
                 }
                 headers.forEach((key, value) {
-                  xhr.setRequestHeader(key, value);
+                  if (key != "useCookies") {
+                    xhr.setRequestHeader(key, value);
+                  }
                 });
               },
             ),


### PR DESCRIPTION
Since the `useCookies` header is being removed, and then the headers are being reused in subsequent requests, only the first `xhr` request will actually send cookies.