### PR TITLE
Do not error on non-fatal event from hls.js

### DIFF
--- a/lib/hls.dart
+++ b/lib/hls.dart
@@ -35,3 +35,14 @@ class HlsConfig {
 
   external factory HlsConfig({Function xhrSetup});
 }
+
+class ErrorData {
+  late final String type;
+  late final String details;
+  late final bool fatal;
+  ErrorData(dynamic errorData) {
+    type = errorData.type;
+    details = errorData.details;
+    fatal = errorData.fatal;
+  }
+}

--- a/lib/video_player_web_hls.dart
+++ b/lib/video_player_web_hls.dart
@@ -253,11 +253,14 @@ class _VideoPlayer {
           _hls!.loadSource(uri.toString());
         }));
         _hls!.on('hlsError', allowInterop((_, dynamic data) {
-          eventController.addError(PlatformException(
-            code: _kErrorValueToErrorName[2]!,
-            message: _kDefaultErrorMessage,
-            details: _kErrorValueToErrorDescription[5],
-          ));
+          var _data = ErrorData(data);
+          if (_data.fatal) {
+            eventController.addError(PlatformException(
+              code: _kErrorValueToErrorName[2]!,
+              message: _data.type,
+              details: _data.details,
+            ));
+          }
         }));
         videoElement.onCanPlay.listen((dynamic _) {
           if (!isInitialized) {


### PR DESCRIPTION
This PR warrants some discussion around how to handle non-fatal errors, but it should probably not be adding an error to the stream, as the `VideoPlayerController` will enter an error state, after which video cannot play.

An example of a non-fatal error would be [bufferStalledError](https://github.com/video-dev/hls.js/blob/master/src/errors.ts#L72).