### PR TITLE
Fix video buffering crashing on slow networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.1.1
+* Fixed video buffering crashing on slow networks (#53)
 ## 1.1.0
 * Updated http dependency
 ## 1.0.0+3

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -259,7 +259,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0+4"
+    version: "1.1.1"
 sdks:
   dart: ">=3.0.0 <4.0.0"
   flutter: ">=3.3.0"

--- a/lib/src/video_player.dart
+++ b/lib/src/video_player.dart
@@ -107,13 +107,17 @@ class VideoPlayer {
           _hls!.loadSource(uri.toString());
         }));
         _hls!.on('hlsError', allowInterop((dynamic _, dynamic data) {
-          final ErrorData _data = ErrorData(data);
-          if (_data.fatal) {
-            _eventController.addError(PlatformException(
-              code: _kErrorValueToErrorName[2]!,
-              message: _data.type,
-              details: _data.details,
-            ));
+          try {
+            final ErrorData _data = ErrorData(data);
+            if (_data.fatal) {
+              _eventController.addError(PlatformException(
+                code: _kErrorValueToErrorName[2]!,
+                message: _data.type,
+                details: _data.details,
+              ));
+            }
+          } catch (e) {
+            debugPrint('Error parsing hlsError: $e');
           }
         }));
         _videoElement.onCanPlay.listen((dynamic _) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/balvinderz/video_player_web_hls
 # 0.1.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 1.1.0
+version: 1.1.1
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Fixes video buffering crashing on slow networks.

When the video buffering was is not quick enough to keep up with the network, `hls.js` throws a `hlsError` to notify. This error is caught by the Flutter interop of this plugin, but the parsing to `ErrorData` fails.

This causes the whole implementation to completely crash and will prevent any more file fragments to be loaded into Flutter. Even when the network is back to stable, no more buffering will occur, the video is stuck.

## How to reproduce

It is not possible to reproduce the issue in debug mode, since

> Flutter web's local server (the one that powers flutter run) DOES NOT support range requests

[source](https://github.com/flutter/packages/tree/main/packages/video_player/video_player_web#some-videos-restart-when-using-the-seek-barprogress-barscrubber)

- Build the example application with `flutter run -d chrome --profile`
- Open the chrome inspector and throttle the network speed
- Start the video playback until the end of the buffered content is hit (to see this, I added a `VideoProgressIndicator` in my example app)

Even under full network the video can't be resumed because the implementation crashed.

## Fix

My fix is simple and just catches any exceptions caused by unexpected event parsing at `hlsError`.
This results in the integration continuing to buffer videos and playback once a fragment is received.

## Related issues

Fixes #52

Even if it doesn't look like it in the first place, the issue linked above are fixed by this PR.
It is the exact stacktrace which lead me to this bug. (doesn't occur anymore in the latest version of `hls.js@1.5.x`