### PR TITLE
Fallback to hlsjs when native player fails

### DIFF
--- a/lib/src/video_player.dart
+++ b/lib/src/video_player.dart
@@ -333,6 +333,7 @@ class VideoPlayer {
   }
 
   bool canPlayHlsNatively() {
+    return false;
     bool canPlayHls = false;
     try {
       final String canPlayType = _videoElement.canPlayType('application/vnd.apple.mpegurl');


### PR DESCRIPTION
When a browser is not sure if it can play a video it will return 'maybe' from here `_videoElement.canPlayType('application/vnd.apple.mpegurl');`, this library takes this as a yes.

I have added a mechanesim to fallback to using hlsjs when the native player failed to play the video.


Refs:
https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/canPlayType

https://github.com/balvinderz/video_player_web_hls/issues/41